### PR TITLE
chore: option --vocoder-path is invalid and should use underscore.

### DIFF
--- a/fs2/cli.py
+++ b/fs2/cli.py
@@ -315,7 +315,7 @@ def synthesize(
     ),
     output_dir: Path = typer.Option(
         "synthesis_output",
-        "--output_dir",
+        "--output-dir",
         "-o",
         file_okay=False,
         dir_okay=True,
@@ -328,8 +328,8 @@ def synthesize(
         None, "--filelist", "-f", exists=True, file_okay=True, dir_okay=False
     ),
     name: CONFIGS_ENUM = typer.Option(None, "--name", "-n"),
-    output_type: List[SynthesisOutputs] = typer.Option(..., "-O", "--output_type"),
-    vocoder_path: Path = typer.Option(None, "--vocoder_path", "-v"),
+    output_type: List[SynthesisOutputs] = typer.Option(..., "-O", "--output-type"),
+    vocoder_path: Path = typer.Option(None, "--vocoder-path", "-v"),
 ):
     # TODO: allow for changing of language/speaker and variance control
     import torch


### PR DESCRIPTION
Refer to https://github.com/roedoejet/EveryVoice/issues/27#issue-1724481477