### PR TITLE
fix: Excluding `sub_dir_callable` when creating a TensorBoardLogger

### DIFF
--- a/fs2/cli.py
+++ b/fs2/cli.py
@@ -630,7 +630,7 @@ def synthesize(  # noqa: C901
         model.config.training.validation_filelist = filelist
         data = FastSpeech2DataModule(model.config)
         tensorboard_logger = TensorBoardLogger(
-            **(model.config.training.logger.model_dump())
+            **(model.config.training.logger.model_dump(exclude={"sub_dir_callable"}))
         )
         trainer = Trainer(
             logger=tensorboard_logger,


### PR DESCRIPTION
fixes: https://github.com/roedoejet/EveryVoice/issues/200