### PR TITLE
build: require Python 3.10 now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open(path.join(this_directory, "requirements.txt"), encoding="utf8") as f:
 
 setup(
     name="fs2l",
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     version=VERSION,
     author="Aidan Pine",
     author_email="hello@aidanpine.ca",


### PR DESCRIPTION
no refactoring code because it would introduce too many conflicts with #20 