### PR TITLE
refactor(tests): only support running tests as modules, not as main file

### DIFF
--- a/fs2/tests/test_cli.py
+++ b/fs2/tests/test_cli.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 If you've installed `everyvoice` and would like to run this unittest:
 python -m unittest everyvoice.model.feature_prediction.FastSpeech2_lightning.fs2.tests.test_cli
@@ -9,30 +7,16 @@ import io
 from contextlib import redirect_stderr
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from unittest import TestCase, main
+from unittest import TestCase
 
 from everyvoice.tests.stubs import mute_logger
 from everyvoice.utils import generic_dict_loader
 from typer.testing import CliRunner
 
-try:
-    from ..cli.cli import app
-    from ..cli.synthesize import prepare_data as prepare_synthesize_data
-    from ..cli.synthesize import validate_data_keys_with_model_keys
-    from ..config import FastSpeech2Config
-except ImportError:
-    from everyvoice.model.feature_prediction.FastSpeech2_lightning.fs2.cli.cli import (
-        app,
-    )
-    from everyvoice.model.feature_prediction.FastSpeech2_lightning.fs2.cli.synthesize import (
-        prepare_data as prepare_synthesize_data,
-    )
-    from everyvoice.model.feature_prediction.FastSpeech2_lightning.fs2.cli.synthesize import (
-        validate_data_keys_with_model_keys,
-    )
-    from everyvoice.model.feature_prediction.FastSpeech2_lightning.fs2.config import (
-        FastSpeech2Config,
-    )
+from ..cli.cli import app
+from ..cli.synthesize import prepare_data as prepare_synthesize_data
+from ..cli.synthesize import validate_data_keys_with_model_keys
+from ..config import FastSpeech2Config
 
 DEFAULT_LANG2ID: set = set()
 DEFAULT_SPEAKER2ID: set = set()
@@ -306,7 +290,3 @@ class CLITest(TestCase):
                 self.assertEqual(result.exit_code, 0)
                 result = self.runner.invoke(app, [subcommand, "-h"])
                 self.assertEqual(result.exit_code, 0)
-
-
-if __name__ == "__main__":
-    main()

--- a/fs2/tests/test_lookuptable.py
+++ b/fs2/tests/test_lookuptable.py
@@ -1,11 +1,9 @@
-#!/usr/bin/env python
-
 """
 If you've installed `everyvoice` and would like to run this unittest:
 python -m unittest everyvoice.model.feature_prediction.FastSpeech2_lightning.fs2.tests.test_lookuptable
 """
 
-from unittest import TestCase, main
+from unittest import TestCase
 
 
 class LookupTableTest(TestCase):
@@ -17,15 +15,6 @@ class LookupTableTest(TestCase):
 
         from everyvoice.text.lookups import LookupTable as lt1
 
-        try:
-            from fs2.type_definitions import LookupTable as lt2
-        except ImportError:
-            from everyvoice.model.feature_prediction.FastSpeech2_lightning.fs2.type_definitions import (
-                LookupTable as lt2,
-            )
+        from ..type_definitions import LookupTable as lt2
 
         self.assertEqual(lt1, lt2)
-
-
-if __name__ == "__main__":
-    main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ ensure_newline_before_comments=True
 [mypy]
 ignore_missing_imports = True
 plugins = pydantic.mypy
+namespace_packages = False
 
 [flake8]
 ignore = E203, E266, E501, W503


### PR DESCRIPTION
My desire to support `cd fs2/tests; ./test_cli.py` is causing unecessary complexity in the imports in the unit tests in this submodule, and that's just not worth it.

So now tests in fs2 will just have to be invoked in a way that python knows they in package fs2.tests.*, e.g.:
 - python -m unittest fs2/tests/test_cli.py
 - similar commands from a higher ancestor directory

or when the modules are installed:
 - python -m unittest fs2.tests.test_cli
 - python -m unittest everyvoice.model.feature_prediction.FastSpeech2_lightning.fs2.tests.test_cli

and of course the CLI entry points
 - cd fs2; ./run_tests.py
 - everyvoice test fs2