### PR TITLE
fix: adjust missing vocoder error messages to refer to the command line only

### DIFF
--- a/fs2/prediction_writing_callback.py
+++ b/fs2/prediction_writing_callback.py
@@ -182,8 +182,8 @@ class PredictionWritingWavCallback(Callback):
             import sys
 
             logger.error(
-                "Sorry, no vocoder was provided, please add it to model.config.training.vocoder_path"
-                " or as --vocoder-path /path/to/vocoder in the command line"
+                "No vocoder was provided, please specify "
+                "--vocoder-path /path/to/vocoder on the command line."
             )
             sys.exit(1)
         else:


### PR DESCRIPTION
We no longer store the vocoder path in the checkpoint, so the error message should not suggest defining it there.

Also remove duplicate error checking for model_path: pydantic already enforces that it is required, no need to redo it.

And check for CLI errors before loading models, for a friendlier user interface.

Replaces #52 to correctly fix https://github.com/roedoejet/EveryVoice/issues/246 without introducing new issues.