### PR TITLE
docs: add license info for derived work

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -22,6 +22,33 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+The above work is derived from the following sources:
+
+MIT License
+
+Copyright (c) 2020, Chung-Ming Chien.  https://github.com/ming024/FastSpeech2
+Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved. https://github.com/NVIDIA/DeepLearningExamples/tree/master/PyTorch/SpeechSynthesis/FastPitch
+Copyright (c) 2021 Keon Lee. https://github.com/keonlee9420/Comprehensive-Transformer-TTS
+Copyright (c) 2022 Christoph Minixhofer. https://github.com/MiniXC/LightningFastSpeech2/blob/main/LICENSE
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 For files in fs2/attn/:
 
 Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.


### PR DESCRIPTION
These changes were merged in EV's submodule links, but they weren't merged in this repo yet. I agree with the changes.