### PR TITLE
perf: speed up the cli by deferring all pydantic imports

### DIFF
--- a/fs2/cli/audit.py
+++ b/fs2/cli/audit.py
@@ -24,7 +24,7 @@ def audit(
     import torch
 
     from ..config import FastSpeech2Config
-    from ..type_definitions import Stats, StatsInfo
+    from ..type_definitions_heavy import Stats, StatsInfo
 
     def check_stats(data, path, stats: StatsInfo):
         import torch

--- a/fs2/cli/train.py
+++ b/fs2/cli/train.py
@@ -12,7 +12,7 @@ def train(**kwargs):
     from ..config import FastSpeech2Config
     from ..dataset import FastSpeech2DataModule
     from ..model import FastSpeech2
-    from ..type_definitions import Stats
+    from ..type_definitions_heavy import Stats
 
     config_args = kwargs["config_args"]
     config_file = kwargs["config_file"]

--- a/fs2/model.py
+++ b/fs2/model.py
@@ -21,7 +21,7 @@ from .layers import PositionalEmbedding, PostNet
 from .loss import FastSpeech2Loss
 from .noam import NoamLR
 from .synthesizer import get_synthesizer
-from .type_definitions import InferenceControl, Stats
+from .type_definitions_heavy import InferenceControl, Stats
 from .utils import mask_from_lens, plot_attn_maps, plot_mel
 from .variance_adaptor import VarianceAdaptor
 
@@ -321,6 +321,11 @@ class FastSpeech2(pl.LightningModule):
             if not self.config.model.learn_alignment:
                 # energy targets are frame-wise if alignment is learned
                 gt_energy_for_plotting = expand(gt_energy_for_plotting, duration_np)
+
+        # plot_mel() requires stat, but self.stats is actually Optional
+        # TODO: if self.stats is always set by the time we get here, OK, if not
+        # skip this step when it's missing or give the user a helpful error message
+        assert self.stats is not None
 
         self.logger.experiment.add_figure(
             f"pred/spec_{batch['basename'][0]}",

--- a/fs2/type_definitions.py
+++ b/fs2/type_definitions.py
@@ -1,6 +1,10 @@
-from enum import Enum
+"""
+This file is for light-weight type definitions with no dependencies.
+This should load in milliseconds.
+Expensive type definitions, e.g., requiring pydantic, belong in type_definitions_heavy.py.
+"""
 
-from pydantic import BaseModel, ConfigDict
+from enum import Enum
 
 
 class SynthesizeOutputFormats(str, Enum):
@@ -8,25 +12,3 @@ class SynthesizeOutputFormats(str, Enum):
 
     wav = "wav"
     spec = "spec"
-
-
-class InferenceControl(BaseModel):
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    pitch: float = 1.0
-    energy: float = 1.0
-    duration: float = 1.0
-
-
-class StatsInfo(BaseModel):
-    min: float
-    max: float
-    std: float
-    mean: float
-    norm_min: float
-    norm_max: float
-
-
-class Stats(BaseModel):
-    pitch: StatsInfo
-    energy: StatsInfo

--- a/fs2/type_definitions_heavy.py
+++ b/fs2/type_definitions_heavy.py
@@ -1,0 +1,32 @@
+"""
+This file is for types that are reused, but potentionally expensive to load.
+Types requiring pydantic belong here.
+Enums and other light-weight types should be defined in type_definitions.py instead.
+
+Be careful not to cause this file to be imported when the CLI is launched, so that
+everyvoice -h and command line completion can remain fast.
+"""
+
+from pydantic import BaseModel, ConfigDict
+
+
+class InferenceControl(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    pitch: float = 1.0
+    energy: float = 1.0
+    duration: float = 1.0
+
+
+class StatsInfo(BaseModel):
+    min: float
+    max: float
+    std: float
+    mean: float
+    norm_min: float
+    norm_max: float
+
+
+class Stats(BaseModel):
+    pitch: StatsInfo
+    energy: StatsInfo

--- a/fs2/utils.py
+++ b/fs2/utils.py
@@ -3,7 +3,7 @@ from typing import Optional
 import torch
 from matplotlib import pyplot as plt
 
-from .type_definitions import Stats
+from .type_definitions_heavy import Stats
 
 
 def plot_attn_maps(attn_softs, attn_hards, mel_lens, text_lens, n=4):

--- a/fs2/variance_adaptor.py
+++ b/fs2/variance_adaptor.py
@@ -12,7 +12,7 @@ from .attn.alignment import mas_width1
 from .attn.attention import ConvAttention
 from .config import FastSpeech2Config
 from .layers import VarianceConvolutionLayer
-from .type_definitions import InferenceControl, Stats, StatsInfo
+from .type_definitions_heavy import InferenceControl, Stats, StatsInfo
 
 
 class VariancePredictor(nn.Module):
@@ -174,9 +174,9 @@ class VarianceAdaptor(nn.Module):
                 hard_attn = mas_width1(
                     log_attn_cpu[ind, 0, : out_lens_cpu[ind], : in_lens_cpu[ind]]
                 )
-                attn_out_cpu[
-                    ind, 0, : out_lens_cpu[ind], : in_lens_cpu[ind]
-                ] = hard_attn
+                attn_out_cpu[ind, 0, : out_lens_cpu[ind], : in_lens_cpu[ind]] = (
+                    hard_attn
+                )
             attn_out = torch.tensor(attn_out_cpu, device=attn.device, dtype=attn.dtype)
         return attn_out
 


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Get the CLI even faster, by avoiding all pydantic imports. Prompted once again by typing `everyvoice new<tab>` and being annoyed at the delay getting results.

According to CI this PR brings `everyvoice -h` down from .28s to .21s, but on GPSCC I'm seeing .65 down to .50 so I care more, and where I also really wish I could optimize further...

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

My impatience. Well, no, it doesn't fix my impatience, it only satisfies a little bit of it. 😄 

### Feedback sought? <!-- What should reviewers focus on in particular? -->

I'm not sure about the name `fs2/types_expensive.py`. First I called it `fs2/shared_types.py` to parallel what we do in ev/config, but it's not shared so that makes no sense. `fs2/type_definitions.py` was nicely self-documenting, and I feel I'm partially undoing that, so suggestions for a better name are very welcome.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

Normal

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

Should already be covered by CI.

### How to test? <!-- Explain how reviewers should test this PR. -->

`time everyvoice -h` before and after the PR.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

High for the code changes, low for the file name.

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

<!-- Add any other relevant information here -->
