### PR TITLE
Dev.ej/clarify text to spec

### DIFF
--- a/fs2/cli/synthesize.py
+++ b/fs2/cli/synthesize.py
@@ -280,7 +280,7 @@ def synthesize(  # noqa: C901
         file_okay=True,
         exists=True,
         dir_okay=False,
-        help="The path to a trained text-to-spec or e2e EveryVoice model.",
+        help="The path to a trained text-to-spec (i.e., feature prediction) or e2e EveryVoice model.",
         autocompletion=complete_path,
     ),
     output_dir: Path = typer.Option(

--- a/fs2/cli/train.py
+++ b/fs2/cli/train.py
@@ -20,7 +20,7 @@ def train(**kwargs):
     lang2id, speaker2id = lookuptables_from_config(config)
 
     # TODO: What about when we are fine-tuning? Do the bins in the Variance Adaptor not change? https://github.com/EveryVoiceTTS/FastSpeech2_lightning/issues/28
-    with open(config.preprocessing.save_dir / "stats.json") as f:
+    with open(config.preprocessing.save_dir / "stats.json", encoding="utf8") as f:
         stats: Stats = Stats(**json.load(f))
 
     model_kwargs = {"lang2id": lang2id, "speaker2id": speaker2id, "stats": stats}


### PR DESCRIPTION
It always takes me too long to figure out which model I need to provide when the help says I need a text-to-spec model.

This PR clarifies that.

Details in https://github.com/EveryVoiceTTS/EveryVoice/pull/553

Riding along: a missing encoding declaration in an `open()` statement.