### PR TITLE
build: we now need ev 0.2.*

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-everyvoice==0.1.*
+everyvoice==0.2.*


### PR DESCRIPTION
In preparation for releasing 0.2.0a0, we need submodule to depend on `0.2.*`, not `0.1.*`.