### PR TITLE
Add .readalong format output to synthesize

### DIFF
--- a/fs2/cli/synthesize.py
+++ b/fs2/cli/synthesize.py
@@ -342,10 +342,10 @@ def synthesize(  # noqa: C901
         "--output-type",
         help="""Which format(s) to synthesize to.
         Multiple formats can be provided by repeating `--output-type`.
-        **wav** is the default and will synthesize to a playable audio file;
-        **spec** will generate predicted Mel spectrograms. Tensors are time-oriented (T, K) where T is equal to the number of frames and K is equal to the number of Mel bands.
-        **textgrid** will generate a Praat TextGrid with alignment labels. This can be helpful for evaluation.
-        **readalong** will generate a ReadAlong from the given text and synthesized audio.
+        '**wav**' is the default and will synthesize to a playable audio file;
+        '**spec**' will generate predicted Mel spectrograms. Tensors are time-oriented (T, K) where T is equal to the number of frames and K is equal to the number of Mel bands.
+        '**textgrid**' will generate a Praat TextGrid with alignment labels. This can be helpful for evaluation.
+        '**readalong**' will generate a ReadAlong from the given text and synthesized audio (see https://github.com/ReadAlongs).
         """,
     ),
     teacher_forcing_directory: Path = typer.Option(

--- a/fs2/cli/synthesize.py
+++ b/fs2/cli/synthesize.py
@@ -345,6 +345,7 @@ def synthesize(  # noqa: C901
         **wav** is the default and will synthesize to a playable audio file;
         **spec** will generate predicted Mel spectrograms. Tensors are time-oriented (T, K) where T is equal to the number of frames and K is equal to the number of Mel bands.
         **textgrid** will generate a Praat TextGrid with alignment labels. This can be helpful for evaluation.
+        **readalong** will generate a ReadAlong from the given text and synthesized audio.
         """,
     ),
     teacher_forcing_directory: Path = typer.Option(

--- a/fs2/prediction_writing_callback.py
+++ b/fs2/prediction_writing_callback.py
@@ -25,7 +25,7 @@ def get_synthesis_output_callbacks(
     vocoder_model: Optional[HiFiGAN] = None,
     vocoder_config: Optional[HiFiGANConfig] = None,
     vocoder_global_step: Optional[int] = None,
-):
+) -> list[Callback]:
     """
     Given a list of desired output file formats, return the proper callbacks
     that will generate those files.

--- a/fs2/prediction_writing_callback.py
+++ b/fs2/prediction_writing_callback.py
@@ -351,12 +351,11 @@ class PredictionWritingReadAlongCallback(PredictionWritingAlignedTextCallback):
     def save_aligned_text_to_file(self, max_seconds, phones, words, language, filename):
         """Save the aligned text as a .readalong file"""
 
-        # Convert the (time, end, label) word tuples into RAS Tokens
         ras_tokens: list[Token] = []
-        for word in words:
+        for start, end, label in words:
             if ras_tokens:
-                ras_tokens.append(Token(" "))
-            ras_tokens.append(Token(word[2], word[0], word[1]))
+                ras_tokens.append(Token(text=" ", is_word=False))
+            ras_tokens.append(Token(text=label, time=start, dur=end - start))
 
         readalong = convert_to_readalong([ras_tokens], [language])
         with open(filename, "w", encoding="utf8") as f:

--- a/fs2/tests/test_writing_callbacks.py
+++ b/fs2/tests/test_writing_callbacks.py
@@ -11,12 +11,8 @@ from pympi import TextGrid
 from pytorch_lightning import Trainer
 
 from ..config import FastSpeech2Config, FastSpeech2TrainingConfig
-from ..prediction_writing_callback import (
-    PredictionWritingReadAlongCallback,
-    PredictionWritingSpecCallback,
-    PredictionWritingTextGridCallback,
-    PredictionWritingWavCallback,
-)
+from ..prediction_writing_callback import get_synthesis_output_callbacks
+from ..type_definitions import SynthesizeOutputFormats
 from ..utils import BASENAME_MAX_LENGTH, truncate_basename
 
 
@@ -121,12 +117,14 @@ class TestWritingSpec(WritingTestBase):
         with TemporaryDirectory() as tmp_dir:
             tmp_dir = Path(tmp_dir)
             with silence_c_stderr():
-                writer = PredictionWritingSpecCallback(
+                writer = get_synthesis_output_callbacks(
+                    [SynthesizeOutputFormats.spec],
                     config=FastSpeech2Config(contact=self.contact),
                     global_step=77,
                     output_dir=tmp_dir,
                     output_key=self.output_key,
-                )
+                    device=torch.device("cpu"),
+                )[0]
             writer.on_predict_batch_end(
                 _trainer=None,
                 _pl_module=None,
@@ -164,12 +162,14 @@ class TestWritingTextGrid(WritingTestBase):
         with TemporaryDirectory() as tmp_dir:
             tmp_dir = Path(tmp_dir)
             with silence_c_stderr():
-                writer = PredictionWritingTextGridCallback(
+                writer = get_synthesis_output_callbacks(
+                    [SynthesizeOutputFormats.textgrid],
                     config=FastSpeech2Config(contact=self.contact),
                     global_step=77,
                     output_dir=tmp_dir,
                     output_key=self.output_key,
-                )
+                    device=torch.device("cpu"),
+                )[0]
             writer.on_predict_batch_end(
                 _trainer=None,
                 _pl_module=None,
@@ -213,12 +213,14 @@ class TestWritingReadAlong(WritingTestBase):
         with TemporaryDirectory() as tmp_dir:
             tmp_dir = Path(tmp_dir)
             with silence_c_stderr():
-                writer = PredictionWritingReadAlongCallback(
+                writer = get_synthesis_output_callbacks(
+                    [SynthesizeOutputFormats.readalong],
                     config=FastSpeech2Config(contact=self.contact),
                     global_step=77,
                     output_dir=tmp_dir,
                     output_key=self.output_key,
-                )
+                    device=torch.device("cpu"),
+                )[0]
             writer.on_predict_batch_end(
                 _trainer=None,
                 _pl_module=None,
@@ -269,7 +271,8 @@ class TestWritingWav(WritingTestBase):
             trainer.save_checkpoint(vocoder_path)
 
             with silence_c_stderr():
-                writer = PredictionWritingWavCallback(
+                writer = get_synthesis_output_callbacks(
+                    [SynthesizeOutputFormats.wav],
                     config=FastSpeech2Config(
                         contact=self.contact,
                         training=FastSpeech2TrainingConfig(vocoder_path=vocoder_path),
@@ -281,7 +284,7 @@ class TestWritingWav(WritingTestBase):
                     vocoder_model=vocoder,
                     vocoder_config=vocoder.config,
                     vocoder_global_step=10,
-                )
+                )[0]
             writer.on_predict_batch_end(
                 _trainer=None,
                 _pl_module=None,

--- a/fs2/type_definitions.py
+++ b/fs2/type_definitions.py
@@ -13,3 +13,4 @@ class SynthesizeOutputFormats(str, Enum):
     wav = "wav"
     spec = "spec"
     textgrid = "textgrid"
+    readalong = "readalong"


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Add the ability to output .readalong files from synthesize

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Fixes https://github.com/EveryVoiceTTS/EveryVoice/issues/439

### Feedback sought? <!-- What should reviewers focus on in particular? -->

This one should get a decent analysis of the code, not just rubber stamping.

One thing that bugs me is the test case hacked in `test_writing_callbacks.py`: I can't figure out how to make it have two words (or more). It would be nice to exercise that, because there is some logic both in TextGrid output and .readalong output that would benefit from being unit tested on more than one input word.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

beta

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

yes

### How to test? <!-- Explain how reviewers should test this PR. -->

Run
```
everyvoice synthesize from-text --text "This, is a test." -O readalong -O textgrid -v voc.ckpt fs2.ckpt
```
and take a look at `synthesis_output/readalongs/*`

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

Pretty good.

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

part of the next release anywayh

### Related PRs? <!-- Parent Everyvoice PR or other submodule PRs required for this PR to make sense. -->

https://github.com/ReadAlongs/Studio/pull/253
https://github.com/EveryVoiceTTS/EveryVoice/pull/607


<!-- Add any other relevant information here -->
