### PR TITLE
fix: take into account duration control for readalong output

### DIFF
--- a/fs2/tests/test_writing_callbacks.py
+++ b/fs2/tests/test_writing_callbacks.py
@@ -98,6 +98,7 @@ class WritingTestBase(TestCase):
                 "short",
                 "This utterance is way too long",
             ],
+            "duration_control": [1.0, 1.0],
             "raw_text": ["test", "W̱SÁNEĆ"],
             "text": [
                 torch.IntTensor([2, 3, 4, 5, 6, 7, 8], device="cpu"),


### PR DESCRIPTION

<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Fix the time dilation issues when we synthesize to readalongs format.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Fixes https://github.com/EveryVoiceTTS/EveryVoice/issues/646

### Feedback sought? <!-- What should reviewers focus on in particular? -->

Marc: Test that this fixes the problems observed before. CI does not exercise this code, so manual testing is warranted.
Aidan: review the logic of the code

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

normal

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

no

### How to test? <!-- Explain how reviewers should test this PR. -->

Run the demo or everyvoice synthesize, and generate readalong-html output with the duration multiplier set to a value other than the default 1.0 value. Make sure the words are aligned correctly, like when the duration multiplier is 1.0.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

### Related PRs? <!-- Parent Everyvoice PR or other submodule PRs required for this PR to make sense. -->



<!-- Add any other relevant information here -->
