### PR TITLE
fix: Accept a single line input file in synthesize

### DIFF
--- a/fs2/cli/synthesize.py
+++ b/fs2/cli/synthesize.py
@@ -98,6 +98,10 @@ def load_data_from_filelist(
             }
             for d in data
         ]
+        if not data:
+            # If there is no data, it means we had a one-line input file. Raise KeyError
+            # so we enter the except block below and read it as a plain text file.
+            raise KeyError
     except KeyError:
         # TODO: Errors should have better formatting:
         #       https://github.com/EveryVoiceTTS/FastSpeech2_lightning/issues/26

--- a/fs2/tests/test_loading.py
+++ b/fs2/tests/test_loading.py
@@ -244,41 +244,27 @@ class StubModelWithConfigOnly:
 
 class TestLoadingData(TestCase):
 
-    def test_load_oneline(self):
-        with tempfile.TemporaryDirectory() as tmpdir_str:
-            tmpdir = Path(tmpdir_str)
+    def write_and_load(self, file_contents: str):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_file = Path(tmpdir) / "data_file"
+            with open(data_file, "w") as f:
+                f.write(file_contents)
             with silence_c_stderr():
-                with open(tmpdir / "oneline.txt", "w") as f:
-                    f.write("this is a test\n")
                 data = load_data_from_filelist(
-                    tmpdir / "oneline.txt",
+                    data_file,
                     StubModelWithConfigOnly(),
                     DatasetTextRepresentation.characters,
                 )
-                self.assertEqual(len(data), 1)
+            return data
+
+    def test_load_oneline(self):
+        data = self.write_and_load("this is a test\n")
+        self.assertEqual(len(data), 1)
 
     def test_load_twolines(self):
-        with tempfile.TemporaryDirectory() as tmpdir_str:
-            tmpdir = Path(tmpdir_str)
-            with silence_c_stderr():
-                with open(tmpdir / "twolines.txt", "w") as f:
-                    f.write("test line 1\ntest line 2\n")
-                data = load_data_from_filelist(
-                    tmpdir / "twolines.txt",
-                    StubModelWithConfigOnly(),
-                    DatasetTextRepresentation.characters,
-                )
-                self.assertEqual(len(data), 2)
+        data = self.write_and_load("test line 1\ntest line 2\n")
+        self.assertEqual(len(data), 2)
 
     def test_load_psv(self):
-        with tempfile.TemporaryDirectory() as tmpdir_str:
-            tmpdir = Path(tmpdir_str)
-            with silence_c_stderr():
-                with open(tmpdir / "psv.psv", "w") as f:
-                    f.write("characters|language\nfoo|eng\nbar|eng\nbaz|fra\n")
-                data = load_data_from_filelist(
-                    tmpdir / "psv.psv",
-                    StubModelWithConfigOnly(),
-                    DatasetTextRepresentation.characters,
-                )
-                self.assertEqual(len(data), 3)
+        data = self.write_and_load("characters|language\nfoo|eng\nbar|eng\nbaz|fra\n")
+        self.assertEqual(len(data), 3)


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Allow the user to pass a single-line text file to `everyvoice synthesize` with the `-f` switch, and test loading such data.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Fixes https://github.com/EveryVoiceTTS/EveryVoice/issues/690

### Feedback sought? <!-- What should reviewers focus on in particular? -->

sanity checking

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

yup

### How to test? <!-- Explain how reviewers should test this PR. -->

    echo "this is a test" > oneline.txt
    everyvoice synthesize from-text -v logs_and_checkpoints/VocoderExperiment/base/checkpoints/last.ckpt -f oneline.txt  logs_and_checkpoints/FeaturePredictionExperiment/base/checkpoints/last.ckpt

Before this PR, this generates nothing at all in `synthesis_output/wav`, on this branch it generates the wav for one test sentence.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

### Related PRs? <!-- Parent Everyvoice PR or other submodule PRs required for this PR to make sense. -->

yes, there will be, later.

<!-- Add any other relevant information here -->
