### PR TITLE
dev.jl/get lengths from data

### DIFF
--- a/fs2/tests/test_cli.py
+++ b/fs2/tests/test_cli.py
@@ -429,21 +429,6 @@ class CLITest(PreprocessedAudioFixture, BasicTestCase):
         self.assertLess(checked_data[0]["pesq"], 5.0)
         self.assertAlmostEqual(checked_data[0]["duration"], 5.17, 2)
 
-    # def test_compute_stats(self):
-    #     feat_prediction_config = EveryVoiceConfig.load_config_from_path().feature_prediction
-    #     preprocessor = Preprocessor(feat_prediction_config)
-    #     preprocessor.compute_stats()
-    # self.assertEqual(
-    #     self.preprocessor.config["preprocessing"]["audio"]["mel_mean"],
-    #     -4.018,
-    #     places=3,
-    # )
-    # self.assertEqual(
-    #     self.preprocessor.config["preprocessing"]["audio"]["mel_std"],
-    #     4.017,
-    #     places=3,
-    # )
-
     def test_commands_present(self):
         """
         Each subcommand is present in the the command's help message.

--- a/fs2/type_definitions_heavy.py
+++ b/fs2/type_definitions_heavy.py
@@ -7,6 +7,8 @@ Be careful not to cause this file to be imported when the CLI is launched, so th
 everyvoice -h and command line completion can remain fast.
 """
 
+from typing import Optional
+
 from pydantic import BaseModel, ConfigDict
 
 
@@ -30,3 +32,6 @@ class StatsInfo(BaseModel):
 class Stats(BaseModel):
     pitch: StatsInfo
     energy: StatsInfo
+    character_length: Optional[StatsInfo] = None
+    phone_length: Optional[StatsInfo] = None
+    arpabet_length: Optional[StatsInfo] = None


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Using the calculated character and phone length stats (see main PR), synthesize splits text using max as its max_length and mean as its desired_length.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Fixes https://github.com/EveryVoiceTTS/EveryVoice/issues/660

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

None in the submodule. In fact, many unit tests cannot access a stats.json file, because they synthesize based on dummy models, so the following was added to keep unit tests chunking at a default length:

```
try:
    # Code to set lengths based on stats.json
except AttributeError:
    # This is here for unit testing
    desired_length = 100
    max_length = 200
```

### How to test? <!-- Explain how reviewers should test this PR. -->

1. Create an EV project, and train a model on phones (make sure to set `target_text_representation_level: phones` in the FP config). Doesn't have to be a good one, just needs the config of this project.
2. After preprocessing, check that stats.json contains chararacter_length and phone_length (with reasonable values).
3. Use the model to synthesize from phones (--text-representation=phones) and from characters. Check that chunking is being performed based on lengths from stats.json (can be done with a breakpoint or print stmt in synthesize.py line 130/line 279).

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

patch

### Related PRs? <!-- Parent Everyvoice PR or other submodule PRs required for this PR to make sense. -->

https://github.com/EveryVoiceTTS/EveryVoice/pull/731

<!-- Add any other relevant information here -->
