### PR TITLE
ci: we no longer need libsox

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
-          packages: sox libsox-dev ffmpeg
+          packages: sox ffmpeg
 
       - name: Fetch everyvoice
         run: |


### PR DESCRIPTION
remove the no-longer required libsox-dev package

See https://github.com/EveryVoiceTTS/EveryVoice/pull/791